### PR TITLE
typo

### DIFF
--- a/pygsp/graphs/nngraphs/spherehealpix.py
+++ b/pygsp/graphs/nngraphs/spherehealpix.py
@@ -63,7 +63,7 @@ class SphereHealpix(NNGraph):
         coords = np.vstack([x, y, z]).transpose()
         coords = np.asarray(coords, dtype=np.float32)
         if n_neighbors is None:
-            n_neighbors = 6 if Nside==1 else 8
+            n_neighbors = 6 if nside==1 else 8
             
         self.opt_std = dict()
         # TODO: find best interpolator between n_side and n_neighbors.


### PR DESCRIPTION
there was a typo at line 66. 
Also, why is `n_neighbors=50` the default options if it will raise an error at line 132? Could `None` be a better option?